### PR TITLE
Makefile fix to enable build for "unix-armv7-hardfloat-neon"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ endif
 
 TARGET_NAME := minivmac
 
-ifeq ($(platform), unix)
-   CC = gcc
+ifneq (,$(findstring unix,$(platform)))
+   CC ?= gcc
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    SHARED := -shared -Wl,--version-script=libretro/link.T -Wl,--no-undefined -fPIC


### PR DESCRIPTION
Made "unix" platform detection more flexible to allow compilation for "unix-armv7-hardfloat-neon" (one of the options in libretro-super build scripts).

CC definition changed to optional to allow cross-compilation.
